### PR TITLE
Compat: Minecraft 26.1.2 + malilib 0.28.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ author = shaijana
 mod_file_name = uwmatica-fabric
 
 # Current mod version
-mod_version = 0.6.13
+mod_version = 0.6.14
 
 # Required malilib version
 malilib_version = 0.28.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,11 +12,11 @@ mod_file_name = uwmatica-fabric
 mod_version = 0.6.13
 
 # Required malilib version
-malilib_version = 0.28.1
+malilib_version = 0.28.6
 
 # Minecraft, Fabric Loader and API and mappings versions
-minecraft_version_out = 26.1
-minecraft_version = 26.1
+minecraft_version_out = 26.1.2
+minecraft_version = 26.1.2
 
 fabric_loader_version = 0.18.4
 mod_menu_version = 18.0.0-alpha.8

--- a/src/main/java/fi/dy/masa/litematica/gui/GuiSchematicManager.java
+++ b/src/main/java/fi/dy/masa/litematica/gui/GuiSchematicManager.java
@@ -3,6 +3,7 @@ package fi.dy.masa.litematica.gui;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Screenshot;
@@ -125,7 +126,7 @@ public class GuiSchematicManager extends GuiSchematicBrowserBase implements ISel
 	        buttonWidth = this.getStringWidth(this.editType.getDisplayName()) + 10;
 	        button = new ConfigButtonOptionList(x, y, buttonWidth, 20, new EditSchematicWrapper());
 
-	        if (this.editType.getHoverText() != null)
+	        if (!this.editType.getHoverText().isEmpty())
 	        {
 		        button.setHoverStrings(this.editType.getHoverText());
 	        }
@@ -135,7 +136,7 @@ public class GuiSchematicManager extends GuiSchematicBrowserBase implements ISel
 		    buttonWidth = this.getStringWidth(this.exportType.getDisplayName()) + 10;
 		    button = new ConfigButtonOptionList(x, y, buttonWidth, 20, new ExportTypeWrapper());
 
-		    if (this.exportType.getHoverText() != null)
+		    if (!this.exportType.getHoverText().isEmpty())
 		    {
 			    button.setHoverStrings(this.exportType.getHoverText());
 		    }
@@ -145,7 +146,7 @@ public class GuiSchematicManager extends GuiSchematicBrowserBase implements ISel
 	        buttonWidth = this.getStringWidth(this.fileOpType.getDisplayName()) + 10;
 	        button = new ConfigButtonOptionList(x, y, buttonWidth, 20, new FileOpsWrapper());
 
-	        if (this.fileOpType.getHoverText() != null)
+	        if (!this.fileOpType.getHoverText().isEmpty())
 	        {
 		        button.setHoverStrings(this.fileOpType.getHoverText());
 	        }
@@ -588,10 +589,10 @@ public class GuiSchematicManager extends GuiSchematicBrowserBase implements ISel
             return StringUtils.translate(this.label);
         }
 
-	    @Nullable
-	    public String getHoverText()
+	    @Override
+	    public List<String> getHoverText()
 	    {
-		    return this.hoverText != null ? StringUtils.translate(this.hoverText) : null;
+		    return this.hoverText != null ? List.of(StringUtils.translate(this.hoverText)) : List.of();
 	    }
 
         @Override
@@ -670,10 +671,10 @@ public class GuiSchematicManager extends GuiSchematicBrowserBase implements ISel
 			return StringUtils.translate(this.label);
 		}
 
-		@Nullable
-		public String getHoverText()
+		@Override
+		public List<String> getHoverText()
 		{
-			return this.hoverText != null ? StringUtils.translate(this.hoverText) : null;
+			return this.hoverText != null ? List.of(StringUtils.translate(this.hoverText)) : List.of();
 		}
 
 		@Override
@@ -752,10 +753,10 @@ public class GuiSchematicManager extends GuiSchematicBrowserBase implements ISel
 			return StringUtils.translate(this.label);
 		}
 
-		@Nullable
-		public String getHoverText()
+		@Override
+		public List<String> getHoverText()
 		{
-			return this.hoverText != null ? StringUtils.translate(this.hoverText) : null;
+			return this.hoverText != null ? List.of(StringUtils.translate(this.hoverText)) : List.of();
 		}
 
 		@Override

--- a/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerDaemonHandler.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerDaemonHandler.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.ChunkPos;
 
 import fi.dy.masa.malilib.interfaces.IThreadDaemonHandler;
 import fi.dy.masa.malilib.util.MathUtils;
+import fi.dy.masa.malilib.util.thread.ThreadExecutorPair;
 import fi.dy.masa.litematica.Litematica;
 import fi.dy.masa.litematica.Reference;
 import fi.dy.masa.litematica.render.LitematicaRenderer;
@@ -25,7 +26,7 @@ public class PlacementManagerDaemonHandler implements IThreadDaemonHandler<Place
 	private final String namePrefix = Reference.MOD_NAME+" Placement Manager";
 	private static final float TASK_INTERVAL = 1.50F;
 	private final int threadCount = this.calculateMaxThreads();
-	private final ConcurrentHashMap<String, Thread> threadMap = this.builder();
+	private final ConcurrentHashMap<String, ThreadExecutorPair<PlacementManagerTask>> threadMap = this.builder();
 	private final LinkedBlockingQueue<PlacementManagerTask> queueUnload = new LinkedBlockingQueue<>();
 	private final LinkedBlockingQueue<PlacementManagerTask> queueRebuild = new LinkedBlockingQueue<>();
 	private final LinkedBlockingQueue<PlacementManagerTask> queueOther = new LinkedBlockingQueue<>();
@@ -41,9 +42,9 @@ public class PlacementManagerDaemonHandler implements IThreadDaemonHandler<Place
 		return MathUtils.clamp(result, 1, MAX_PLATFORM_THREADS);
 	}
 
-	private ConcurrentHashMap<String, Thread> builder()
+	private ConcurrentHashMap<String, ThreadExecutorPair<PlacementManagerTask>> builder()
 	{
-		ConcurrentHashMap<String, Thread> threads = new ConcurrentHashMap<>(this.threadCount, 0.9f, 1);
+		ConcurrentHashMap<String, ThreadExecutorPair<PlacementManagerTask>> threads = new ConcurrentHashMap<>(this.threadCount, 0.9f, 1);
 
 		for (int i = 0; i < this.threadCount; i++)
 		{
@@ -84,8 +85,8 @@ public class PlacementManagerDaemonHandler implements IThreadDaemonHandler<Place
 			catch (IllegalStateException is)
 			{
 				// Terminated
-				Thread entry = this.threadFactory(key, this.useVirtual, new PlacementManagerDaemonExecutor());
-				entry.start();
+				ThreadExecutorPair<PlacementManagerTask> entry = this.threadFactory(key, this.useVirtual, new PlacementManagerDaemonExecutor());
+				entry.thread().start();
 
 				synchronized (this.threadMap)
 				{
@@ -285,8 +286,8 @@ public class PlacementManagerDaemonHandler implements IThreadDaemonHandler<Place
 				catch (IllegalStateException is)
 				{
 					// Terminated (Replace)
-					Thread entry = this.threadFactory(key, this.useVirtual, new PlacementManagerDaemonExecutor());
-					entry.start();
+					ThreadExecutorPair<PlacementManagerTask> entry = this.threadFactory(key, this.useVirtual, new PlacementManagerDaemonExecutor());
+					entry.thread().start();
 
 					synchronized (this.threadMap)
 					{

--- a/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerTask.java
+++ b/src/main/java/fi/dy/masa/litematica/schematic/placement/PlacementManagerTask.java
@@ -4,10 +4,10 @@ import java.util.function.Supplier;
 
 import net.minecraft.world.level.ChunkPos;
 
-import fi.dy.masa.malilib.interfaces.DefaultThreadTaskBase;
+import fi.dy.masa.malilib.interfaces.AbstractThreadTaskBase;
 import fi.dy.masa.litematica.world.WorldSchematic;
 
-public abstract class PlacementManagerTask extends DefaultThreadTaskBase
+public abstract class PlacementManagerTask extends AbstractThreadTaskBase
 {
 	private final Supplier<WorldSchematic> worldSupplier;
 	private final int chunkX;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,11 +33,11 @@
     "accessWidener": "litematica.accesswidener",
 
 	"depends": {
-		"minecraft": "26.1",
-		"malilib": ">=0.28.1- <0.29.0-"
+		"minecraft": "~26.1",
+		"malilib": ">=0.28.6- <0.29.0-"
 	},
 	"breaks": {
-		"malilib": "<0.28.1-",
+		"malilib": "<0.28.6-",
 		"sodium": "<0.8.7-",
 		"iris": "<1.10.8-"
 	}


### PR DESCRIPTION
Hi shaijana,

ich habe uwmatica lokal gegen 26.1.2 und malilib 0.28.6 neu
kompiliert, weil das aktuelle Release für mich (26.1.2 Client) nicht
startet. Falls hilfreich, gerne übernehmen — sonst einfach schließen.

## Änderungen

- **Versionen:** `minecraft` auf `26.1.2` (in `fabric.mod.json` als
  `~26.1`), `malilib` auf `0.28.6` (aktuelle Version aus dem
  sakura-ryoko-Maven für 26.1.2).
- **API-Drift in malilib 0.28.6 nachgezogen:**
  - `DefaultThreadTaskBase` → `AbstractThreadTaskBase`
    (`PlacementManagerTask`)
  - `threadMap` von `Thread` auf `ThreadExecutorPair<PlacementManagerTask>`
    (`PlacementManagerDaemonHandler`); `entry.start()` →
    `entry.thread().start()`
  - `IConfigOptionListEntry.getHoverText()` Rückgabetyp `String` →
    `List<String>` in den drei Enums in `GuiSchematicManager`;
    Aufrufer-Checks von `!= null` auf `!isEmpty()`

Nur Start mit aktuellem Fabric/malilib-26.1.2-Stack verifiziert. Keine Funktionstests darüber hinaus gemacht. Keine Verhaltensänderungen beabsichtigt, ausschließlich Kompatibilitäts-Anpassungen.

vg
mark